### PR TITLE
ci: fix require

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
-require "test-unit"
+require "test/unit"
 require "test/unit/rr"
 require "fluent/test"
 require "fluent/test/driver/input"


### PR DESCRIPTION
This patch will fix following error when run test:

```
$ bundle exec rake
/home/watson/.rbenv/versions/3.3.9/bin/ruby -w -I"lib:lib:test" /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/plugin/test_in_fluent_package_update_notifier.rb"
/home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:36:in `block in included': undefined method `setup' for class Test::Unit::TestCase (NoMethodError)

            setup :before => :prepend
            ^^^^^
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:35:in `module_eval'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:35:in `included'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:110:in `include'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:110:in `<class:TestCase>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:109:in `<module:Unit>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:24:in `<top (required)>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/watson/src/fluent-plugin-fluent-package-update-notifier/test/helper.rb:2:in `<top (required)>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/watson/src/fluent-plugin-fluent-package-update-notifier/test/plugin/test_in_fluent_package_update_notifier.rb:1:in `<top (required)>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `select'
        from /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib:test" /home/watson/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/plugin/test_in_fluent_package_update_notifier.rb" ]
/home/watson/.rbenv/versions/3.3.9/bin/bundle:25:in `load'
/home/watson/.rbenv/versions/3.3.9/bin/bundle:25:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```