### PR TITLE
test: fix failure

### DIFF
--- a/fluent-plugin-fluent-package-update-notifier.gemspec
+++ b/fluent-plugin-fluent-package-update-notifier.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "rake", "~> 13.2.1"
-  spec.add_development_dependency "test-unit", "~> 3.6.7"
+  spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "test-unit-rr", "~> 1.0.5"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 


### PR DESCRIPTION
Another idea for #1
It appears that the current CI failure is caused by `test-unit 3.6.9` (see https://github.com/test-unit/test-unit/issues/320).

    $ bundle exec rake test
    /home/daipom/.rbenv/versions/3.2.2/bin/ruby -w -I"lib:lib:test" /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/plugin/test_in_fluent_package_update_notifier.rb"
    /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:36:in `block in included': undefined method `setup' for Test::Unit::TestCase:Class (NoMethodError)

                setup :before => :prepend
                ^^^^^
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:35:in `module_eval'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:35:in `included'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:110:in `include'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:110:in `<class:TestCase>'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:109:in `<module:Unit>'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/test-unit-rr-1.0.5/lib/test/unit/rr.rb:24:in `<top (required)>'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from /home/daipom/work/fluentd/plugins/fluent-plugin-fluent-package-update-notifier/test/helper.rb:2:in `<top (required)>'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from /home/daipom/work/fluentd/plugins/fluent-plugin-fluent-package-update-notifier/test/plugin/test_in_fluent_package_update_notifier.rb:1:in `<top (required)>'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from <internal:/home/daipom/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `select'
    	from /home/daipom/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `<main>'
    rake aborted!