### PR TITLE
gemspec: move development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "bundler", "~> 2.4"
+gem "rake", "~> 13.2.1"
+gem "test-unit", "~> 3.0"
+gem "test-unit-rr", "~> 1.0.5"
+gem "rubocop-fluentd", "~> 0.2.0"

--- a/fluent-plugin-fluent-package-update-notifier.gemspec
+++ b/fluent-plugin-fluent-package-update-notifier.gemspec
@@ -28,13 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "specinfra", "~> 2.94.1"
-
-  spec.add_development_dependency "bundler", "~> 2.4"
-  spec.add_development_dependency "rake", "~> 13.2.1"
-  spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_development_dependency "test-unit-rr", "~> 1.0.5"
-  spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
-
-  spec.add_development_dependency "rubocop-fluentd", "~> 0.2.0"
+  spec.add_dependency "specinfra", "~> 2.94.1"
+  spec.add_dependency "fluentd", [">= 0.14.10", "< 2"]
 end


### PR DESCRIPTION
It is recommended to use Gemfile instead of `add_development_dependency`.

* https://github.com/rubygems/bundler/pull/7222