### PR TITLE
Use :cmd backend for Windows platform

### DIFF
--- a/lib/fluent/plugin/fluent_package_update_checker.rb
+++ b/lib/fluent/plugin/fluent_package_update_checker.rb
@@ -24,7 +24,7 @@ module Fluent
             @logger.error "Failed to load #{ENV["FLUENT_PACKAGE_CONFIG"] || DEFAULT_PACKAGE_CONFIG_PATH}"
           end
           @host_os = RbConfig::CONFIG['host_os']
-          Specinfra.configuration.backend = :exec
+          Specinfra.configuration.backend = windows? ? :cmd : :exec
           @os_info = Specinfra.backend.os_info
         end
 


### PR DESCRIPTION
Seems `:exec` assumes Linux environment.

So, this patch uses `:cmd` as backend on Windows.