### PR TITLE
Rubocop: Fix Bundler/OrderedGems and Performance/FluentdPluginLogStringInterpolation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem "bundler", "~> 2.4"
 gem "rake", "~> 13.2.1"
+gem "rubocop-fluentd", "~> 0.2.0"
 gem "test-unit", "~> 3.0"
 gem "test-unit-rr", "~> 1.0.5"
-gem "rubocop-fluentd", "~> 0.2.0"

--- a/lib/fluent/plugin/in_fluent_package_update_notifier.rb
+++ b/lib/fluent/plugin/in_fluent_package_update_notifier.rb
@@ -72,7 +72,7 @@ module Fluent
           checker = Fluent::Plugin::FluentPackage::UpdateChecker.new(options)
           checker.run
         rescue => e
-          log.error "Failed to check updates: #{e.message}"
+          log.error { "Failed to check updates: #{e.message}" }
         end
       end
     end


### PR DESCRIPTION
This patch will fix following Rubocop's suggestions:

```
$ bundle exec rubocop
Inspecting 5 files
C...C

Offenses:

Gemfile:8:1: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem rubocop-fluentd should appear before test-unit.
gem "test-unit-rr", "~> 1.0.5" ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Gemfile:9:1: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem rubocop-fluentd should appear before test-unit-rr.
gem "rubocop-fluentd", "~> 0.2.0"
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/fluent/plugin/in_fluent_package_update_notifier.rb:75:11: C: Performance/FluentdPluginLogStringInterpolation: Use log.error { "..." } instead of log.error("...")
          log.error "Failed to check updates: #{e.message}"
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

5 files inspected, 3 offenses detected, 2 offenses autocorrectable
```
