### PR TITLE
Relax log level

### DIFF
--- a/lib/fluent/plugin/in_fluent_package_update_notifier.rb
+++ b/lib/fluent/plugin/in_fluent_package_update_notifier.rb
@@ -72,7 +72,7 @@ module Fluent
           checker = Fluent::Plugin::FluentPackage::UpdateChecker.new(options)
           checker.run
         rescue => e
-          log.error { "Failed to check updates: #{e.message}" }
+          log.info { "Failed to check updates: #{e.message}" }
         end
       end
     end


### PR DESCRIPTION
When used in an offline environment, the message will be shown at error level every 24 hours.
I think some users may feel this annoying.

So, this patch will change `error` to `info` level.