### PR TITLE
in_fluent_package_update_notifier: support multi worker

### DIFF
--- a/lib/fluent/plugin/in_fluent_package_update_notifier.rb
+++ b/lib/fluent/plugin/in_fluent_package_update_notifier.rb
@@ -40,6 +40,10 @@ module Fluent
       desc "Package repository site"
       config_param :repository_sites, :array, default: ["https://packages.treasuredata.com"]
 
+      def multi_workers_ready?
+        true
+      end
+
       def configure(conf)
         super
       end

--- a/test/plugin/test_in_fluent_package_update_notifier.rb
+++ b/test/plugin/test_in_fluent_package_update_notifier.rb
@@ -30,6 +30,11 @@ class FluentPackageUpdateNotifierInputTest < Test::Unit::TestCase
     ]
   end
 
+  test "multi worker" do
+    d = create_driver
+    assert_true d.instance.multi_workers_ready?
+  end
+
   sub_test_case "configuration test" do
     test "default configuration" do
       assert_nothing_raised do


### PR DESCRIPTION
If confiured using multi worker, `in_fluent_package_update_notifier` causes following config error.

### config
```
<system>
  workers 2
</system>

<source>
  @type fluent_package_update_notifier
</source>

```

### error
```
2025-08-27 17:20:33 +0900 [error]: config error file="/home/watson/prj/sandbox/fluentd/fluent.conf" error_class=Fluent::ConfigError error="Plugin 'fluent_package_update_notifier' does not support multi workers configuration (Fluent::Plugin::FluentPackageUpdateNotifierInput)"
```

This PR will solve above config error.