### PR TITLE
ci: use sha pinning to mitigate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - windows-latest
     name: Test with Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies


### PR DESCRIPTION
Lower risk about supply chain attack even though matched tag was compromised.